### PR TITLE
Update B4c+ Guidelines

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -207,8 +207,7 @@ To be more informative, each Guideline is classified using one of the following 
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
 - B2f+) [CLARIFICATION] Since the competitor starts the solve by lifting the cover, penalties for starting the timer and for touching the cover while starting the attempt do not apply (see [Regulation B2b](regulations:regulation:B2b) and [Regulation B2c](regulations:regulation:B2c)).
-- B4c+) [ADDITION] If the judge forgot to put a sight blocker, or places it in a way that the competitor's view of the puzzle is not fully blocked, the WCA Delegate should grant an extra attempt.
-- B4c++) [ADDITION] If the WCA Delegate does not suspect that the competitor intentionally violated any WCA Regulations, the original attempt may stand.
+- B4c+) [ADDITION] If the judge forgot to put a sight blocker and the WCA Delegate does not suspect that the competitor intentionally violated any WCA Regulations, the original attempt may stand.
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -1,6 +1,6 @@
 # <wca-title>WCA Guidelines
 
-<version>Version: January 1, 2024
+<version>Version: January 1, 2025
 
 
 ## Notes

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -1,6 +1,6 @@
 # <wca-title>WCA Guidelines
 
-<version>Version: January 1, 2025
+<version>Version: January 1, 2024
 
 
 ## Notes

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -1,6 +1,6 @@
 # <wca-title>WCA Regulations
 
-<version>Version: January 1, 2024
+<version>Version: January 1, 2025
 
 
 ## Notes

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -1,6 +1,6 @@
 # <wca-title>WCA Regulations
 
-<version>Version: January 1, 2025
+<version>Version: January 1, 2024
 
 
 ## Notes


### PR DESCRIPTION
In line with Board precedent, clarifies that the default should be to keep the result