### PR TITLE
Clarify clock solved state

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -1,6 +1,6 @@
 # <wca-title>WCA Guidelines
 
-<version>Version: January 1, 2024
+<version>Version: January 1, 2025
 
 
 ## Notes

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -1,6 +1,6 @@
 # <wca-title>WCA Guidelines
 
-<version>Version: January 1, 2025
+<version>Version: January 1, 2024
 
 
 ## Notes

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -311,6 +311,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 10f4) Square-1: at most 45 degrees (U/D) or 90 degrees (/).
 - 10h) Puzzles not specified in this article are judged according to the solved state as defined by the generally accepted goal of the puzzle.
     - 10h1) The solved state of Clock is achieved when all eighteen inner clock faces point to 12 o'clock.
+        - 10h1a) Inner clock faces that do not clearly point to a particular hour marker are considered to point to the nearest hour marker.
 
 
 ## <article-11><incidents><incidents> Article 11: Incidents

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -1,6 +1,6 @@
 # <wca-title>WCA Regulations
 
-<version>Version: January 1, 2024
+<version>Version: January 1, 2025
 
 
 ## Notes

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -1,6 +1,6 @@
 # <wca-title>WCA Regulations
 
-<version>Version: January 1, 2025
+<version>Version: January 1, 2024
 
 
 ## Notes


### PR DESCRIPTION
Explicitly state for clock the arrows are considered to point to the closer hour if the position is indeterminate