### PR TITLE
2i1 Inconsistency fix

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -57,7 +57,6 @@ To be more informative, each Guideline is classified using one of the following 
 - 2i+++++) [EXAMPLE] Examples that are not considered using an electronic device: moving a camera, flipping over a phone, wearing a smartwatch.
 - 2i++++++) [EXAMPLE] Examples of using an electronic device: pressing a camera button, checking a message on a phone or smartwatch.
 - 2i1b+) [CLARIFICATION] This includes relevant devices which are switched off or disconnected.
-- 2i1c+) [CLARIFICATION] Electronic hand warmers are considered electronic devices, and therefore are not permitted while inspecting or solving. However, non-electronic hand warmers may be used at any time during an attempt.
 - 2i2+) [CLARIFICATION] The competitor may hold or wear a camera anywhere, as long as the live feed of the camera is not visible to the competitor.
 - 2j2+) [EXAMPLE] For example, if a competitor is disqualified from an event for failing to show up for the final round, their results from earlier rounds remain valid.
 - 2j2++) [EXAMPLE] If the WCA Delegate disqualifies a competitor during their third attempt in a round, only the third attempt and all following attempts in that event are disqualified, even if the circumstances that originated the disqualification occurred prior to this attempt.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -85,7 +85,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 2i1) Competitors may use non-electronic aids that do not give an unfair advantage, at the discretion of the WCA Delegate. This includes:
         - 2i1a) Medical/physical aids worn by the competitor (e.g. glasses, wrist brace). As an exception to [Regulation 2i](regulations:regulation:2i), medical aids may be electronic if the competitor does not have comfortable non-electronic alternatives (e.g. if the competitor has a personal hearing aid or pacemaker).
         - 2i1b) Earplugs and earmuffs (but not electronic headphones and earbuds).
-        - 2i1c) Hand warmers.
+        - 2i1c) Non-electronic hand warmers.
         - 2i1d) Food and drink.
     - 2i2) Competitors may use cameras at the solving station at the discretion of the WCA Delegate, but the following restrictions apply from the start of the attempt until the competitor stops the solve. Penalty for breaking a restriction: disqualification of the attempt (DNF).
         - 2i2a) Each camera monitor must be blank or out of sight of the competitor (see [Regulation A5b](regulations:regulation:A5b)).


### PR DESCRIPTION
2i1b clarifies that electronic earbuds are not allowed in the Regulation, but 2i1c only specifies that electronic handwarmers are not allowed in the guideline and not in the regulation itself, which has caused misinterpretation. 

This PR also removes the guideline as cleanup, I don't think it is necessary with this addition but I would be fine with keeping it if people feel strongly that way. 