### PR TITLE
Clarify Timer Starts

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -187,6 +187,7 @@ To be more informative, each Guideline is classified using one of the following 
 - A3c3++) [CLARIFICATION] The competitor cannot "test" or "restart" the timer during inspection, since inspection ends once the competitor starts the solve (see [Regulation A4d](regulations:regulation:A4d)). If the competitor stops the timer after they have started it for the first time, this is considered stopping the solve (see [Regulation A6](regulations:regulation:A6)), even if they do so within 15 seconds of starting inspection.
 - A3c4+) [CLARIFICATION] If the use of a thin object inside the puzzle has been enforced, the judge must not remove the object on behalf of the competitor.
 - A3c4++) [CLARIFICATION] The competitor may remove the object during the solve, if they did not do it during the inspection (e.g. they forgot).
+- A4b+) [CLARIFICATION] The competitor should use at least four fingers from each hand and more than one phalange from each finger (i.e. not the fingertip alone).
 - A4d1+) [CLARIFICATION] If the inspection took exactly 15 seconds (i.e. 15.00), the time penalty (+2 seconds) must be applied.
 - A4d2+) [CLARIFICATION] If the inspection took exactly 17 seconds (i.e. 17.00), the attempt must be disqualified (DNF).
 - A5b+) [CLARIFICATION] While inspecting or solving the puzzle, the competitor may touch the puzzle with any part of their body. Exception: 3x3x3 One-Handed (see [Regulation C1b](regulations:regulation:C1b)).

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -417,7 +417,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - A3c5) For Square-1, the competitor should not be penalized for any accidental move made within the limits of [Regulation 10f](regulations:regulation:10f).
     - A3d) At the end of the inspection, the competitor places the puzzle on the mat, in any orientation. Penalty for placing it outside the mat: time penalty (+2 seconds).
 - A4) Starting the solve:
-    - A4b) The competitor uses their fingers to touch the elevated sensor surfaces of the Stackmat timer. The competitor's palms must be facing down, and located on the side of the timer that is closer to the competitor. Penalty: time penalty (+2 seconds).
+    - A4b) The competitor places their fingers flat on the elevated sensor surfaces of the Stackmat timer. The competitor's palms must be facing down, and located on the side of the timer that is closer to the competitor. Penalty: time penalty (+2 seconds).
         - A4b1) The competitor must have no physical contact with the puzzle while starting the solve. Penalty: time penalty (+2 seconds).
     - A4d) If a Stackmat timer is in use, the competitor should keep their hands on the timer until they see a green timer light. The timer is started when they remove their hand(s) from the timer. The competitor starts the solve by starting the timer.
         - A4d1) The competitor must start the solve within 15 seconds of the start of the inspection. Penalty: time penalty (+2 seconds).


### PR DESCRIPTION
Using _should_ for the new guideline to avoid harsh rulings. In any case, this would give delegates and the WRC the chance to reject extras for "timer malfunctions" that were done with flawed timer starts. An example of a flawed timer start:

![Captura de pantalla 2023-07-19 a la(s) 14 24 37](https://github.com/user-attachments/assets/b98cb897-c943-4ff4-bdd9-2607b23921f4)
