### PR TITLE
Clock Orientation Clarification

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -80,6 +80,7 @@ To be more informative, each Guideline is classified using one of the following 
 - 3h++) [EXAMPLE] Examples of enhancements include: new moves are possible, normal moves are impossible, more pieces or faces are visible, colors on the backside of the puzzle are visible, moves are done automatically, or the puzzles have more/different solved states.
 - 3h2++) [CLARIFICATION] "Stickerless" puzzles that significantly differ from most mass-produced "stickerless" puzzles are only permitted at the discretion of the WCA Delegate.
 - 3h2a+) [ADDITION] Examples of transparent parts that do not reveal more information about the state of the puzzle: internal parts of the puzzle mechanism, transparent Clock cases.
+- 3h4+) [CLARIFICATION] For Clock, visual modifications that enhance the ability to determine the orientation of the puzzle are permitted, as traditional inserts already provide this information.
 - 3j++) [EXAMPLE] There is a [Visual Guide](https://drive.google.com/file/d/1m6THsA8fXRN7QFM4ApJbm6eVODKGbMLx/view) available for [Regulation 3j](regulations:regulation:3j).
 - 3k2+) [ADDITION] The WCA Delegate should not apply a listed exception if they believe the competitor tried to use a non-permitted puzzle on purpose.
 - 3k2b+) [CLARIFICATION] If a non-permitted puzzle is found during the course of a 3x3x3 Multi-Blind attempt, the puzzle must not be exchanged or removed from the attempt and must be counted as unsolved if the entire attempt is not disqualified.


### PR DESCRIPTION
Clarifies that modifications that make clock orientation (of the puzzle as a whole, not the pieces themselves) easier to view are fine. 

Potentially could add a note about logos as well. 