### PR TITLE
Add Stationary to 7h

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -221,7 +221,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 7f2) The Stackmat timer must be attached to the mat and placed on the surface, with the timer on the side of the mat nearest to the competitor.
     - 7f3) The organization team should modify Stackmat timers to be more robust against common incidents, by making the buttons more difficult to press by accident (e.g. by attaching O-rings around the buttons) and securing the battery more firmly (e.g. by padding the battery compartment).
     - 7f4) Generation 5 Pro Timer must be used in 2-pad mode.
-- 7h) If competitors do not remain at the same station for all of their attempts in a round, the competition area should have one or more Competitor Waiting Areas.
+- 7h) If competitors do not remain at the same station for all of their attempts in a round, the competition area must have one or more Competitor Waiting Areas.
     - 7h1) The organization team may require that a competitor who has been called to compete must remain within their assigned Competitor Waiting Area until the competitor has finished all attempts for the round.
     - 7h2) Definition: A Competitor Waiting Area is an area in which competitors in a group wait at to be called to a solving station. 
 

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -221,7 +221,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 7f2) The Stackmat timer must be attached to the mat and placed on the surface, with the timer on the side of the mat nearest to the competitor.
     - 7f3) The organization team should modify Stackmat timers to be more robust against common incidents, by making the buttons more difficult to press by accident (e.g. by attaching O-rings around the buttons) and securing the battery more firmly (e.g. by padding the battery compartment).
     - 7f4) Generation 5 Pro Timer must be used in 2-pad mode.
-- 7h) The competition area should have one or more Competitor Waiting Areas.
+- 7h) If competitors do not remain at the same station for all of their attempts in a round, the competition area should have one or more Competitor Waiting Areas.
     - 7h1) The organization team may require that a competitor who has been called to compete must remain within their assigned Competitor Waiting Area until the competitor has finished all attempts for the round.
     - 7h2) Definition: A Competitor Waiting Area is an area in which competitors in a group wait at to be called to a solving station. 
 


### PR DESCRIPTION
Using Stationary seating is not a problem, and organizers should not have to go against a "should" Regulation to use it.

This regulation used to be a must - is there any reason not to change it back?